### PR TITLE
PJSTELTR-4898 removing Lit seb charset rule

### DIFF
--- a/api/v1/common/router.php
+++ b/api/v1/common/router.php
@@ -2533,9 +2533,11 @@ $app->get('/test', function ($request, $response, $args)  {
 function getCharset($request, $dataHandler)
 {
     $contentCharset = $request->getContentCharset();
+    /*
     $headers = $request->getHeaders();
     $sebContentCharset = applySEBCharset($headers, $dataHandler);
     if ($sebContentCharset != "")  $contentCharset = $sebContentCharset;
+    */
     return $contentCharset;
 }
 function applySEBCharset($headers, $dataHandler)


### PR DESCRIPTION
SEB is not used in LIT anymore and SEB has moved their LAT and EST
Request to this server as well so we are applying a wrong charset on the
LAT and EST requests